### PR TITLE
Add Additional Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ git clone https://github.com/alexsurelee/mony.git
 
 2. Install dependencies
 
+If you're performing the installation on a Linux machine, ensure that you have `node` (version >= 20) and `make` installed before installing the dependencies. 
+
 ```
 cd mony
 yarn


### PR DESCRIPTION
This PR adds a small note to step 2 in the `README` to prompt the user to ensure that they have `node` and `make` installed before attempting to use `yarn` to install the dependencies. I followed the installation process on a newly provisioned Linode running `Ubuntu 24.04` and received an error stating that my NodeJS version was too low (must be >= 20 according to the error message). After resolving that issue, I got another error stating that `make` wasn't installed. Resolving both of these allowed the installation of dependencies to complete. `node` and `make` are likely to be installed on a dev machine, but always good to remind the user to check :)

I didn't perform the installation on a Windows machine, so this PR only accounts for the Linux installation process. 

Happy to discuss this further if you'd like 😊